### PR TITLE
Fix dependencies & recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Everything is released under WTFPL license.
 Mod dependencies
 ----------------
 
-- farming (included in minetest)
-- food (https://github.com/rubenwardy/food)
+- food_basic (https://github.com/rubenwardy/food)
 
 Recommended mods
 ----------------

--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,2 @@
 default
-farming
+food_basic

--- a/init.lua
+++ b/init.lua
@@ -90,7 +90,7 @@ minetest.register_node("pizza:pizzabox_open", {
 minetest.register_craft({
     type = "shapeless",
     output = "pizza:pizza_dough",
-    recipe = {"farming:flour", "food:cheese", "food:tomato"},
+    recipe = {"group:food_flour", "group:food_cheese", "group:food_tomato"},
 })
 
 minetest.register_craft({


### PR DESCRIPTION
- Require **food_basic** & remove **farming**.
- Use food groups in **pizza:pizza_dough** recipe.